### PR TITLE
objects/_forms.scss: Dropdown icon not working

### DIFF
--- a/objects/_forms.scss
+++ b/objects/_forms.scss
@@ -78,7 +78,6 @@ $form-text-color: $dark;
     .frm__select {
         @include box-sizing('border-box');
         @include border-radius();
-        @extend %ddgsi-a !optional;
         display: inline-block;
         position: relative;
         overflow: hidden;
@@ -125,7 +124,7 @@ $form-text-color: $dark;
         }
         
         &:after {
-            @include icon('down');
+            @include icon('down', '1');
             
             margin-top: -5px;
             font-size: 12px;

--- a/objects/_forms.scss
+++ b/objects/_forms.scss
@@ -125,7 +125,7 @@ $form-text-color: $dark;
         }
         
         &:after {
-            @include icon('down','1');
+            @include icon('down');
             
             margin-top: -5px;
             font-size: 12px;

--- a/objects/_forms.scss
+++ b/objects/_forms.scss
@@ -124,7 +124,7 @@ $form-text-color: $dark;
         }
         
         &:after {
-            @include icon('down','1');
+            @include icon('down');
             
             margin-top: -5px;
             font-size: 12px;

--- a/objects/_forms.scss
+++ b/objects/_forms.scss
@@ -124,7 +124,7 @@ $form-text-color: $dark;
         }
         
         &:after {
-            @include icon('down', '1');
+            @include icon('down','1');
             
             margin-top: -5px;
             font-size: 12px;


### PR DESCRIPTION
Changing from icon('down', '1') to icon('down') makes it work. @sdougbrown 

![screen shot 2015-09-08 at 4 01 04 pm](https://cloud.githubusercontent.com/assets/81969/9745963/d926e1d0-5642-11e5-8629-db46c0215afa.png)
