### PR TITLE
_vars.scss: Set default border-radius() mixin size to 2px

### DIFF
--- a/_vars.scss
+++ b/_vars.scss
@@ -67,3 +67,5 @@ $landscape1-height: $media--xs * 0.75 !default;
 $landscape2-height: $media--xs * 0.9 !default;
 $landscape2-width:  $media--xs !default;
 
+// Set the default border radius
+$default-border-radius: 2px;


### PR DESCRIPTION
Since the `<select>` needs to be similar between https://github.com/duckduckgo/community-platform and duckduckgo.com, it's probably best to set the `$default-border-radius` variable in this repo.

For @sdougbrown 