### PR TITLE
Make Font Path Absolute

### DIFF
--- a/_vars.scss
+++ b/_vars.scss
@@ -1,4 +1,5 @@
 $html-font-size: 100% !default;
+$asset-path: '';
 
 ////////////////
 // Colors (See also https://github.com/duckduckgo/duckduckgo-colors)

--- a/icons/_ddgsi.scss
+++ b/icons/_ddgsi.scss
@@ -6,11 +6,11 @@
 
 @font-face {
 	font-family: 'ddg-serp-icons';
-	src:url('font/ddg-serp-icons.eot?v=118');
-	src:url('font/ddg-serp-icons.eot?v=118#iefix') format('embedded-opentype'),
-	url('font/ddg-serp-icons.svg?v=118#ddg-serp-icons') format('svg'),
+	src:url($asset-path + '/font/ddg-serp-icons.eot?v=118');
+	src:url($asset-path + '/font/ddg-serp-icons.eot?v=118#iefix') format('embedded-opentype'),
+	url($asset-path + '/font/ddg-serp-icons.svg?v=118#ddg-serp-icons') format('svg'),
 	url($ddg-serp-icons-woff-base64) format('woff'),
-	url('font/ddg-serp-icons.ttf?v=118') format('truetype');
+	url($asset-path + '/font/ddg-serp-icons.ttf?v=118') format('truetype');
 	font-weight: normal;
 	font-style: normal;
 }


### PR DESCRIPTION
Follow-up to #13 in trying to make the font icons more compatible, this adjusts the path for all font files to be absolute.

The `$asset-path` var is available to adjust the path for different sites and use-cases.  I believe that the community platform hosts all files like this from a `/static` folder, so that would need to be updated.

to @bsstoner 
cc @jagtalon 