### PR TITLE
Don't let scrolling happen in the sidebar

### DIFF
--- a/objects/_nav-menu.scss
+++ b/objects/_nav-menu.scss
@@ -230,8 +230,7 @@ $dark-nav-bg: #313235;
     .nav-menu__list {
         padding-left: $base-unit * 1.5;
         position: absolute;
-        overflow: auto;
-        overflow-x: hidden;
+        overflow: hidden;
         bottom: 0;
         right: 0;
         left: 0;

--- a/objects/_nav-menu.scss
+++ b/objects/_nav-menu.scss
@@ -230,7 +230,8 @@ $dark-nav-bg: #313235;
     .nav-menu__list {
         padding-left: $base-unit * 1.5;
         position: absolute;
-        overflow: hidden;
+        overflow: auto;
+        overflow-x: hidden;
         bottom: 0;
         right: 0;
         left: 0;

--- a/objects/_nav-menu.scss
+++ b/objects/_nav-menu.scss
@@ -236,14 +236,6 @@ $dark-nav-bg: #313235;
         right: 0;
         left: 0;
         top: 0;
-        
-        // extra bottom padding so that short screen people can scroll to the bottom
-        &:after {
-            content: "";
-            clear: both;
-            display: block;
-            height: 15em;
-        }
     }
     
     &.is-open {


### PR DESCRIPTION
Tested all the way down to IE 9 and on mobile as well: https://v.usetapes.com/1c247V1q40

Here's how it would look before:

![screen shot 2016-11-10 at 1 48 54 pm](https://cloud.githubusercontent.com/assets/81969/20190106/1200fbc8-a74e-11e6-8845-24b69a5c8637.png)
