### PR TITLE
remove nav menu .is-mobile-device rule

### DIFF
--- a/objects/_nav-menu.scss
+++ b/objects/_nav-menu.scss
@@ -247,10 +247,4 @@ $dark-nav-bg: #313235;
     .csstransforms3d & {
         right: 0;
     }
-    
-    // animation/positioning fixes for very specific instance
-    // mobile touch devices that can re-orient with searchform focus and mess up positioning
-    .is-mobile-device & {
-        position: absolute;
-    }
 }


### PR DESCRIPTION
fixes this nasty layout bug for mobile:
![screen shot 2017-02-28 at 3 54 31 pm](https://cloud.githubusercontent.com/assets/1278969/23439981/40113eac-fdce-11e6-85c1-39c3f802802f.png)
