### PR TITLE
Remove references to blue-darker

### DIFF
--- a/objects/_buttons.scss
+++ b/objects/_buttons.scss
@@ -73,14 +73,10 @@
         
         font-weight: 600;
         
-        &:hover, &:focus {
+        &:hover, &:focus, &:active {
             color: $white;
             background-color: $blue-dark;
             border-color: $blue-dark;
-        }
-        &:active {
-            background-color: $blue-darker;
-            border-color: $blue-darker;
         }
     }
     


### PR DESCRIPTION
This is the only reference to blue-darker in the code base, seems unnecessary, removing it.

/cc @bbraithwaite @moollaza 