### PR TITLE
Fix popover fade-out animation, add darker variation of the popover background

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "duckduckgo-styles",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "homepage": "https://github.com/duckduckgo/duckduckgo-styles",
   "authors": [
     "Brian <brian@duckduckgo.com>",

--- a/objects/_modal-popover.scss
+++ b/objects/_modal-popover.scss
@@ -8,7 +8,7 @@ $popover-shadow: 0 0 15px -3px rgba(0,0,0,0.35);
 
 .modal--popover {
     // default styles
-    @include transition(background 0.15s ease-out);
+    @include transition(background 0.15s ease-out, visibility 0.15s linear);
     display: table;
     overflow: hidden;
     visibility: hidden;
@@ -20,12 +20,12 @@ $popover-shadow: 0 0 15px -3px rgba(0,0,0,0.35);
     right: 0;
     left: 0;
     top: 0;
+    z-index: 300;
 
     &.is-showing {
         background: #ddd;
         background: rgba(white,0.7);
         visibility: visible;
-        z-index: 300;
 
         .modal__box {
             @include transform(scale(1));
@@ -91,6 +91,12 @@ $popover-shadow: 0 0 15px -3px rgba(0,0,0,0.35);
 .modal--popover--dk {
     &.is-showing {
         background: rgba(210,210,210,0.6);
+    }
+}
+
+.modal--popover--dark {
+    &.is-showing {
+        background: rgba(85, 85, 85, 0.9);
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "duckduckgo-styles",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "SCSS styling objects and variables used by DuckDuckGo",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Tested on Chrome, Firefox, Safari, Edge and IE11.

## Fade-out animation fix

Popover fade-out animation wasn't working because 'visibility: hidden' was immediately applied after 'is-shown' class was removed hiding the whole thing instantaneously.

*BEFORE* Gif from production (animation slowed down to 1/4 of regular speed):

![modal-visibility-broken mov](https://user-images.githubusercontent.com/985504/43075239-7d0c32f0-8e80-11e8-8cae-33ebad5b5164.gif)

The fix was to also animate 'visibility'. Also, z-index has to be 300 through the whole animation otherwise search bar will show over the modal background.

*AFTER* (animation slowed down to 1/4 of regular speed):

![modal-visibility-fixed mov](https://user-images.githubusercontent.com/985504/43075315-b65f6734-8e80-11e8-9410-e3a7e77d8ff7.gif)

## Darker background variation

In the manual location project we need a better contrast between the background and the map shown in the popup. See project designs for more info.
