### PR TITLE
Disabled button should look disabled on hover and have a default cursor

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "duckduckgo-styles",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "homepage": "https://github.com/duckduckgo/duckduckgo-styles",
   "authors": [
     "Brian <brian@duckduckgo.com>",

--- a/objects/_buttons.scss
+++ b/objects/_buttons.scss
@@ -30,7 +30,8 @@
 .btn, .button {
     @extend %btn;
     
-    &.is-disabled {
+    &.is-disabled, &.is-disabled:hover, &.is-disabled:active, &.is-disabled:focus {
+        cursor: default;
         border-color: $button-border-alt;
         background-color: $button-border-alt;
         color: #eee;

--- a/objects/_modal-popover.scss
+++ b/objects/_modal-popover.scss
@@ -88,7 +88,7 @@ $popover-shadow: 0 0 15px -3px rgba(0,0,0,0.35);
         opacity: 1;
     }
 }
-.modal--popover--dk {
+.modal--popover--gray {
     &.is-showing {
         background: rgba(210,210,210,0.6);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "duckduckgo-styles",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "SCSS styling objects and variables used by DuckDuckGo",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Fix btn.is-disabled

Currently, adding 'is-disabled' class is not enough to make button behave as disabled:

![disabled-buttons mov](https://user-images.githubusercontent.com/985504/43085762-15ec7dac-8e9c-11e8-9455-c9a8527c471e.gif)

this PR makes sure that cursor and hover state do not suggest that button is enabled

![disabled-buttons-fixed mov](https://user-images.githubusercontent.com/985504/43085814-3f01f1a4-8e9c-11e8-8347-db70222bf3f4.gif)

## Rename modal--popover--dk

As discussed in the [previous PR](https://github.com/duckduckgo/duckduckgo-styles/pull/48#discussion_r204397359), lets rename `modal--popover--dk` to `--gray`

🚨 This is a breaking change so I updated package version to 2.0.0.