### PR TITLE
Remove unnecessary mixins

### DIFF
--- a/objects/_loader.scss
+++ b/objects/_loader.scss
@@ -13,11 +13,11 @@ Loader animation
 
     .is-loading & {
         display: block;
-        @include animation(loader-animate 0.5s steps(15) infinite);
+        animation: loader-animate 0.5s steps(15) infinite;
     }
 }
 
-@include keyframes(loader-animate) {
+@keyframes loader-animate {
     0% {
         background-position: left;
     }


### PR DESCRIPTION
Animation and Keyframes are supported by browsers we support on DuckDuckGo.

Also, we only seem to use this class for IA Pages so this isn't very important if there's any breakage on very old browsers.

Removing these enables use to use node-sass + compass-mixins and passes csslint 👍 